### PR TITLE
fix: restore navigation titles on iOS 26

### DIFF
--- a/DanaKit.xcodeproj/project.pbxproj
+++ b/DanaKit.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		B802D50A2C1F675600B92C35 /* ContinousBluetoothManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B802D5082C1F675600B92C35 /* ContinousBluetoothManager.swift */; };
 		B80C73D62B7D534300821A38 /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80C73D52B7D534300821A38 /* TimeInterval.swift */; };
 		B80EC4B02B45F66E005E2A1A /* DanaKitSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80EC4AF2B45F66E005E2A1A /* DanaKitSettingsView.swift */; };
+		23EE72FA08ABD14A4E70A612 /* View+UIKitNavigationTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A5EF46C17076A73B9D04B5 /* View+UIKitNavigationTitle.swift */; };
 		B80EC4B22B45F681005E2A1A /* DanaKitSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80EC4B12B45F681005E2A1A /* DanaKitSettingsViewModel.swift */; };
 		B8179E5A2B20F2A10049EEE7 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8179E592B20F2A10049EEE7 /* OSLog.swift */; };
 		B81C52242B30E95E00FB801D /* IdentifiableClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C52232B30E95E00FB801D /* IdentifiableClass.swift */; };
@@ -175,6 +176,7 @@
 		B802D5082C1F675600B92C35 /* ContinousBluetoothManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContinousBluetoothManager.swift; sourceTree = "<group>"; };
 		B80C73D52B7D534300821A38 /* TimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInterval.swift; sourceTree = "<group>"; };
 		B80EC4AF2B45F66E005E2A1A /* DanaKitSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DanaKitSettingsView.swift; sourceTree = "<group>"; };
+		63A5EF46C17076A73B9D04B5 /* View+UIKitNavigationTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+UIKitNavigationTitle.swift"; sourceTree = "<group>"; };
 		B80EC4B12B45F681005E2A1A /* DanaKitSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DanaKitSettingsViewModel.swift; sourceTree = "<group>"; };
 		B8179E592B20F2A10049EEE7 /* OSLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
 		B81C52232B30E95E00FB801D /* IdentifiableClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableClass.swift; sourceTree = "<group>"; };
@@ -529,6 +531,7 @@
 				B85335D92B58599300DB470A /* ReservoirView.swift */,
 				B8F4DCA32B94C06100AB00E6 /* Image.swift */,
 				B8F4DCAD2B94CF8100AB00E6 /* ContinueButton.swift */,
+				63A5EF46C17076A73B9D04B5 /* View+UIKitNavigationTitle.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -862,6 +865,7 @@
 				B864F7A22B49EF3800C503A2 /* DanaKitSetupCompleteView.swift in Sources */,
 				B8360A9D2B2646A100152188 /* DanaGeneralAvgBolus.swift in Sources */,
 				B8F4DCA42B94C06100AB00E6 /* Image.swift in Sources */,
+				23EE72FA08ABD14A4E70A612 /* View+UIKitNavigationTitle.swift in Sources */,
 				B80EC4B02B45F66E005E2A1A /* DanaKitSettingsView.swift in Sources */,
 				B8360AD32B2A348100152188 /* DanaHistorySuspend.swift in Sources */,
 				B8360AAF2B2A298200152188 /* DanaGeneralGetUserOption.swift in Sources */,

--- a/DanaKitUI/Views/Onboarding/DanaIExplainationView.swift
+++ b/DanaKitUI/Views/Onboarding/DanaIExplainationView.swift
@@ -47,7 +47,7 @@ struct DanaIExplainationView: View {
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarHidden(false)
-        .navigationTitle(String(localized: "Setting up Dana-i", comment: "Title for dana-i explaination"))
+        .uikitNavigationTitle(String(localized: "Setting up Dana-i", comment: "Title for dana-i explaination"))
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: self.dismiss) {

--- a/DanaKitUI/Views/Onboarding/DanaKitPumpSpeed.swift
+++ b/DanaKitUI/Views/Onboarding/DanaKitPumpSpeed.swift
@@ -70,7 +70,7 @@ struct DanaKitPumpSpeed: View {
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarHidden(false)
-        .navigationTitle(String(localized: "Delivery speed", comment: "Title for delivery speed"))
+        .uikitNavigationTitle(String(localized: "Delivery speed", comment: "Title for delivery speed"))
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: self.dismiss) {

--- a/DanaKitUI/Views/Onboarding/DanaKitScanView.swift
+++ b/DanaKitUI/Views/Onboarding/DanaKitScanView.swift
@@ -35,7 +35,7 @@ struct DanaKitScanView: View {
             }
         }
         .navigationBarHidden(false)
-        .navigationTitle(String(localized: "Pairing", comment: "Title for DanaKitScanView"))
+        .uikitNavigationTitle(String(localized: "Pairing", comment: "Title for DanaKitScanView"))
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {

--- a/DanaKitUI/Views/Onboarding/DanaKitSetupView.swift
+++ b/DanaKitUI/Views/Onboarding/DanaKitSetupView.swift
@@ -58,7 +58,7 @@ struct DanaKitSetupView: View {
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarHidden(false)
-        .navigationTitle(String(localized: "Welcome!", comment: "Onboarding Header"))
+        .uikitNavigationTitle(String(localized: "Welcome!", comment: "Onboarding Header"))
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: self.dismiss) {

--- a/DanaKitUI/Views/Onboarding/DanaRSv3Explaination.swift
+++ b/DanaKitUI/Views/Onboarding/DanaRSv3Explaination.swift
@@ -47,7 +47,7 @@ struct DanaRSv3Explaination: View {
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarHidden(false)
-        .navigationTitle(String(localized: "Setting up DanaRS v3", comment: "Title for danars v3 explaination"))
+        .uikitNavigationTitle(String(localized: "Setting up DanaRS v3", comment: "Title for danars v3 explaination"))
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: self.dismiss) {

--- a/DanaKitUI/Views/Onboarding/InsulinTypeConfirmation.swift
+++ b/DanaKitUI/Views/Onboarding/InsulinTypeConfirmation.swift
@@ -38,6 +38,6 @@ struct InsulinTypeConfirmation: View {
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarHidden(false)
-        .navigationTitle(String(localized: "Insulin Type", comment: "Title for insulin type"))
+        .uikitNavigationTitle(String(localized: "Insulin Type", comment: "Title for insulin type"))
     }
 }

--- a/DanaKitUI/Views/Settings/DanaKitRefillReservoirCannula.swift
+++ b/DanaKitUI/Views/Settings/DanaKitRefillReservoirCannula.swift
@@ -181,7 +181,7 @@ struct DanaKitRefillReservoirAndCannulaView: View {
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarHidden(false)
-        .navigationBarTitle(String(
+        .uikitNavigationTitle(String(
             localized:
             viewModel.cannulaOnly ? "Cannula refill" : "Reservoir/cannula refill",
             comment: "Title for reservoir/cannula refill"

--- a/DanaKitUI/Views/Settings/DanaKitSettingsPumpSpeed.swift
+++ b/DanaKitUI/Views/Settings/DanaKitSettingsPumpSpeed.swift
@@ -69,6 +69,6 @@ struct DanaKitSettingsPumpSpeed: View {
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarHidden(false)
-        .navigationTitle(String(localized: "Delivery speed", comment: "Title for delivery speed"))
+        .uikitNavigationTitle(String(localized: "Delivery speed", comment: "Title for delivery speed"))
     }
 }

--- a/DanaKitUI/Views/Settings/DanaKitSettingsView.swift
+++ b/DanaKitUI/Views/Settings/DanaKitSettingsView.swift
@@ -514,7 +514,7 @@ struct DanaKitSettingsView: View {
         }
         .listStyle(InsetGroupedListStyle())
         .navigationBarItems(trailing: doneButton)
-        .navigationBarTitle(viewModel.pumpModel)
+        .uikitNavigationTitle(viewModel.pumpModel)
     }
 
     private var doneButton: some View {

--- a/DanaKitUI/Views/Settings/DanaKitUserSettingsView.swift
+++ b/DanaKitUI/Views/Settings/DanaKitUserSettingsView.swift
@@ -159,7 +159,7 @@ struct DanaKitUserSettingsView: View {
             )
         }
         .edgesIgnoringSafeArea(.bottom)
-        .navigationBarTitle(String(localized: "User options", comment: "Title for user options"))
+        .uikitNavigationTitle(String(localized: "User options", comment: "Title for user options"))
     }
 
     private func beepFormatter(value: Int) -> String {

--- a/DanaKitUI/Views/Settings/InsulinTypeView.swift
+++ b/DanaKitUI/Views/Settings/InsulinTypeView.swift
@@ -41,7 +41,7 @@ struct InsulinTypeView: View {
         }
         .edgesIgnoringSafeArea(.bottom)
         .navigationBarHidden(false)
-        .navigationTitle(String(localized: "Insulin Type", comment: "Title for insulin type"))
+        .uikitNavigationTitle(String(localized: "Insulin Type", comment: "Title for insulin type"))
     }
 }
 

--- a/DanaKitUI/Views/View+UIKitNavigationTitle.swift
+++ b/DanaKitUI/Views/View+UIKitNavigationTitle.swift
@@ -1,0 +1,97 @@
+//
+//  View+UIKitNavigationTitle.swift
+//  DanaKit
+//
+//  Copyright © 2026 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+extension View {
+    /// Sets the navigation bar title (and large-title display mode) for a SwiftUI screen that is
+    /// hosted inside a UIKit `UINavigationController` — as all of DanaKit's onboarding and settings
+    /// screens are, via `DanaUICoordinator` — whether the screen was pushed by the coordinator or
+    /// via a SwiftUI `NavigationLink`.
+    ///
+    /// Needed because on iOS 26 SwiftUI's `.navigationTitle` / `.navigationBarTitle` no longer
+    /// bridges to a parent UIKit navigation controller, so those titles render blank. This helper
+    /// keeps the SwiftUI modifiers (for earlier iOS) and additionally sets `navigationItem.title`
+    /// directly on the hosting view controller.
+    func uikitNavigationTitle(
+        _ title: String,
+        displayMode: NavigationBarItem.TitleDisplayMode = .automatic
+    ) -> some View {
+        self
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(displayMode)
+            .background(NavigationItemTitleSetter(title: title, largeTitleDisplayMode: displayMode.uiKitLargeTitleDisplayMode))
+    }
+}
+
+private extension NavigationBarItem.TitleDisplayMode {
+    var uiKitLargeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode {
+        switch self {
+        case .inline: return .never
+        case .large: return .always
+        case .automatic: return .automatic
+        @unknown default: return .automatic
+        }
+    }
+}
+
+/// Sets `navigationItem.title` and `largeTitleDisplayMode` on the enclosing navigation
+/// controller's top view controller. See `View.uikitNavigationTitle(_:displayMode:)`.
+private struct NavigationItemTitleSetter: UIViewControllerRepresentable {
+    let title: String
+    let largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode
+
+    func makeUIViewController(context: Context) -> TitleProxyViewController {
+        TitleProxyViewController(title: title, largeTitleDisplayMode: largeTitleDisplayMode)
+    }
+
+    func updateUIViewController(_ uiViewController: TitleProxyViewController, context: Context) {
+        uiViewController.proxyTitle = title
+        uiViewController.largeTitleDisplayMode = largeTitleDisplayMode
+    }
+
+    final class TitleProxyViewController: UIViewController {
+        var proxyTitle: String {
+            didSet { applyTitle() }
+        }
+
+        var largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode {
+            didSet { applyTitle() }
+        }
+
+        init(title: String, largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode) {
+            self.proxyTitle = title
+            self.largeTitleDisplayMode = largeTitleDisplayMode
+            super.init(nibName: nil, bundle: nil)
+            view.isHidden = true
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+            applyTitle()
+        }
+
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            applyTitle()
+        }
+
+        private func applyTitle() {
+            // The hosted SwiftUI screen is the navigation controller's top view controller;
+            // set the title and display mode the navigation bar actually uses.
+            guard let host = navigationController?.topViewController else { return }
+            host.navigationItem.title = proxyTitle
+            host.navigationItem.largeTitleDisplayMode = largeTitleDisplayMode
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On iOS 26, SwiftUI's `.navigationTitle` / `.navigationBarTitle` no longer bridges
to a parent UIKit `UINavigationController`. DanaKit hosts all of its SwiftUI screens
inside `DanaUICoordinator` (a `UINavigationController`) via `DismissibleHostingController`,
so every screen's title — onboarding and settings alike — renders **blank** on iOS 26.

## Fix

Adds a small `View.uikitNavigationTitle(_:displayMode:)` helper that keeps the existing
SwiftUI modifiers (for iOS ≤ 18) and additionally sets `navigationItem.title` (and
`largeTitleDisplayMode`) directly on the hosting view controller, so the title shows on
iOS 26. All 11 hosted screens swap their bare `.navigationTitle` / `.navigationBarTitle`
for it.

This is the same approach already applied to MedtrumKit and PR'd to OmnipodKit and MinimedKit.

## Notes

- The helper is hand-wired into `project.pbxproj` (DanaKit uses explicit file groups, not
  synchronized ones), so it's compiled into the framework target.
- No behavior change on iOS ≤ 25 — the original SwiftUI modifiers are still applied.

## Testing

Verified in Trio via Xcode 26.5 to iPhone simulators (17 Pro iOS 26.5, 14 Plus iOS 18.6). To get past the onboarding and check the other screens, I applied [#9](https://github.com/loopandlearn/DanaKit/pull/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

